### PR TITLE
[김미소][서브헤더] api 분리, share 파일 분리, 이모지 중복기능 수정

### DIFF
--- a/src/api/subHeader.js
+++ b/src/api/subHeader.js
@@ -1,0 +1,18 @@
+import { BASE_URL_RECIPIENT } from '../constants/url';
+
+export const setPostEmoji = async (rollingPageId, method, emoji, type) => {
+  try {
+    await fetch(`${BASE_URL_RECIPIENT}${rollingPageId}/reactions/`, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        emoji,
+        type,
+      }),
+    });
+  } catch (error) {
+    throw new Error('이모지 POST 전송 실패 :', error);
+  }
+};

--- a/src/components/layout/subHeader/EmojiBox.jsx
+++ b/src/components/layout/subHeader/EmojiBox.jsx
@@ -1,26 +1,9 @@
-import './emojiBox.scss';
 import { useRef, useState } from 'react';
-import Emoji from '../../rollingPost/emoji/Emoji';
-import { BASE_URL_RECIPIENT } from '../../../constants/url';
 import data from '@emoji-mart/data';
 import Picker from '@emoji-mart/react';
-
-async function setPostEmoji(rollingPageId, method, emoji, type) {
-  try {
-    await fetch(`${BASE_URL_RECIPIENT}${rollingPageId}/reactions/`, {
-      method,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        emoji,
-        type,
-      }),
-    });
-  } catch (e) {
-    throw new Error('이모지 POST 전송 실패 :', e);
-  }
-}
+import Emoji from '../../rollingPost/emoji/Emoji';
+import { setPostEmoji } from '../../../api/subHeader';
+import './emojiBox.scss';
 
 export default function EmojiBox({ emojis, rollingPageId }) {
   const [isEmojiAdd, setIsEmojiAdd] = useState(false);

--- a/src/components/layout/subHeader/EmojiBox.jsx
+++ b/src/components/layout/subHeader/EmojiBox.jsx
@@ -27,7 +27,7 @@ export default function EmojiBox({ emojis, rollingPageId }) {
   const handleEmojiPickerIconClick = (emojiData) => {
     if (
       !emojiData ||
-      selectedEmojis.some((data) => data.native === emojiData.native)
+      selectedEmojis.some((data) => data.emoji === emojiData.native)
     )
       return;
     // 8개 까지만 emoji 추가

--- a/src/components/layout/subHeader/ShareBox.jsx
+++ b/src/components/layout/subHeader/ShareBox.jsx
@@ -1,7 +1,7 @@
-import './shareBox.scss';
+import Toast from '../../toast/Toast';
 import { useEffect, useState } from 'react';
 import { kakaoShare } from '../../../utills/kakaoShare';
-import Toast from '../../toast/Toast';
+import './shareBox.scss';
 
 const { Kakao } = window;
 const shareURL = window.location.href;
@@ -24,7 +24,7 @@ export default function ShareBox({ name }) {
   const handleToast = (message) => {
     setMessageText(message);
     setIsShowToast(true);
-    setTimeout(() => setIsShowToast(false), 2000);
+    setTimeout(() => setIsShowToast(false), 1500);
   };
 
   // url 공유하기
@@ -38,8 +38,7 @@ export default function ShareBox({ name }) {
             handleToast('URL이 복사 되었습니다.');
           })
           .catch((error) => {
-            handleToast('클립보드 복사 실패');
-            console.log(error);
+            throw new Error('클립보드 복사 실패: ', error);
           });
       }
 
@@ -54,8 +53,7 @@ export default function ShareBox({ name }) {
         handleToast('Web Share API를 지원하지 않는 브라우저입니다.');
       }
     } catch (error) {
-      handleToast('URL 공유 실패');
-      console.log(error);
+      throw new Error('URL 공유 실패: ', error);
     }
   };
 

--- a/src/components/layout/subHeader/SubHeader.jsx
+++ b/src/components/layout/subHeader/SubHeader.jsx
@@ -3,8 +3,8 @@ import { useGetData } from '../../../hooks/useGetData';
 import { BASE_URL_RECIPIENT } from '../../../constants/url';
 import ProfileList from './ProfileList';
 import EmojiBox from './EmojiBox';
-import ShareBox from './ShareBox';
 import './subHeader.scss';
+import ShareBox from '../../share/ShareBox';
 
 export default function SubHeader() {
   const { id } = useParams();

--- a/src/components/layout/subHeader/SubHeader.jsx
+++ b/src/components/layout/subHeader/SubHeader.jsx
@@ -1,10 +1,10 @@
-import './subHeader.scss';
 import { Link, useParams } from 'react-router-dom';
 import { useGetData } from '../../../hooks/useGetData';
 import { BASE_URL_RECIPIENT } from '../../../constants/url';
 import ProfileList from './ProfileList';
 import EmojiBox from './EmojiBox';
 import ShareBox from './ShareBox';
+import './subHeader.scss';
 
 export default function SubHeader() {
   const { id } = useParams();

--- a/src/components/share/ShareBox.jsx
+++ b/src/components/share/ShareBox.jsx
@@ -1,6 +1,6 @@
-import Toast from '../../toast/Toast';
 import { useEffect, useState } from 'react';
-import { kakaoShare } from '../../../utills/kakaoShare';
+import { kakaoShare } from '../../utills/kakaoShare';
+import Toast from '../toast/Toast';
 import './shareBox.scss';
 
 const { Kakao } = window;

--- a/src/components/share/shareBox.scss
+++ b/src/components/share/shareBox.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/_variables';
+@import '../../styles/_variables';
 
 .share-box {
   &--wrap {


### PR DESCRIPTION
### 제목



ex)[홍길동][Header] 헤더 생성

### PR 타입

- [ ] 초기 설정
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 파일 이름 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature-kms -> develop

### 변경 사항
- emoji POST api함수를 Api 폴더로 파일 분리
-  subheader에 있던 ShareBox 파일을 share 파일로 분리
- 이모지 중복선택 에러 수정